### PR TITLE
[ez] alias for openai wrap for consistency and disambiguation

### DIFF
--- a/examples/ibm.py
+++ b/examples/ibm.py
@@ -1,0 +1,40 @@
+import os
+import dotenv
+from ibm_watsonx_ai.foundation_models import Model
+from ibm_watsonx_ai.foundation_models.utils.enums import ModelTypes
+from ibm_watsonx_ai.metanames import GenTextParamsMetaNames as GenParams
+from lastmile_eval.rag.debugger.tracing.sdk import get_lastmile_tracer
+from lastmile_eval.rag.debugger.tracing.auto_instrumentation.ibm import (
+    wrap_watson,
+)
+
+print("Generate")
+
+dotenv.load_dotenv()
+
+# To display example params enter
+GenParams().get_example_values()
+
+generate_params = {GenParams.MAX_NEW_TOKENS: 25}
+
+model = Model(
+    model_id=ModelTypes.GRANITE_13B_CHAT_V2,
+    params=generate_params,
+    credentials=dict(
+        api_key=os.getenv("WATSONX_API_KEY"),
+        url="https://us-south.ml.cloud.ibm.com",
+    ),
+    space_id=os.getenv("WATSONX_SPACE_ID"),
+    verify=None,
+    validate=True,
+)
+
+tracer = get_lastmile_tracer(
+    "elementary-my-dear-watson", os.getenv("LASTMILE_API_TOKEN")
+)
+wrapper = wrap_watson(model, tracer)
+# response = wrapper.generate("the quick brown fox")
+# print(response)
+
+# response = wrapper.generate_text("the quick brown fox")
+# print(response)

--- a/examples/ibm.py
+++ b/examples/ibm.py
@@ -4,9 +4,7 @@ from ibm_watsonx_ai.foundation_models import Model
 from ibm_watsonx_ai.foundation_models.utils.enums import ModelTypes
 from ibm_watsonx_ai.metanames import GenTextParamsMetaNames as GenParams
 from lastmile_eval.rag.debugger.tracing.sdk import get_lastmile_tracer
-from lastmile_eval.rag.debugger.tracing.auto_instrumentation.ibm import (
-    wrap_watson,
-)
+from tracing_auto_instrumentation.ibm import wrap_watson
 
 print("Generate")
 
@@ -33,8 +31,8 @@ tracer = get_lastmile_tracer(
     "elementary-my-dear-watson", os.getenv("LASTMILE_API_TOKEN")
 )
 wrapper = wrap_watson(model, tracer)
-# response = wrapper.generate("the quick brown fox")
-# print(response)
+response = wrapper.generate("This is the generate call")
+print(response)
 
-# response = wrapper.generate_text("the quick brown fox")
-# print(response)
+response = wrapper.generate_text("this is the generate text call")
+print(response)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 lastmile_eval
+ibm-watsonx-ai

--- a/src/tracing_auto_instrumentation/__init__.py
+++ b/src/tracing_auto_instrumentation/__init__.py
@@ -3,8 +3,12 @@ from .llama_index_callback_handler import (
 )
 
 from .langchain_instrumentor import LangChainInstrumentor
+from .ibm import wrap_watson
+from .openai import wrap_openai
 
 __ALL__ = [
     LlamaIndexCallbackHandler.__name__,
     LangChainInstrumentor.__name__,
+    wrap_watson.__name__,
+    wrap_openai.__name__,
 ]

--- a/src/tracing_auto_instrumentation/ibm.py
+++ b/src/tracing_auto_instrumentation/ibm.py
@@ -1,18 +1,19 @@
-from abc import abstractmethod
+import inspect
+import json
 import os
+from abc import abstractmethod
 from typing import Any, Protocol
+import dotenv
 from ibm_watsonx_ai.foundation_models import Model
+from ibm_watsonx_ai.foundation_models.utils.enums import ModelTypes
 from ibm_watsonx_ai.metanames import GenTextParamsMetaNames as GenParams
-from ibm_watsonx_ai.foundation_models.utils.enums import (
-    ModelTypes,
+from lastmile_eval.rag.debugger.api import LastMileTracer
+from lastmile_eval.rag.debugger.tracing.decorators import (
+    _get_serializable_input,
+    _try_log_output,
 )
-
-from lastmile_eval.rag.debugger.tracing.lastmile_tracer import LastMileTracer
-
-from lastmile_eval.rag.debugger.common.query_trace_types import LLMOutputReceived, PromptResolved
 from lastmile_eval.rag.debugger.tracing.wrap_utils import (
     NamedWrapper,
-    json_serialize_anything,
 )
 
 # NamedWrapper = "1"
@@ -38,28 +39,10 @@ class IBMWatsonXGenerateTextStreamMethod(Protocol):
         pass
 
 
-# To display example params enter
-GenParams().get_example_values()
-
-generate_params = {GenParams.MAX_NEW_TOKENS: 25}
-
-model = Model(
-    model_id=ModelTypes.GRANITE_13B_CHAT_V2,
-    params=generate_params,
-    credentials=dict(
-        api_key=os.getenv("WATSONX_API_KEY"),
-        url="https://us-south.ml.cloud.ibm.com",
-    ),
-    verify=None,
-    validate=True,
-)
-
 # print("Generate text:")
 
 # print(model.generate_text("the quick brown fox"))
 
-print("Generate")
-print(model.generate("the quick brown fox"))
 
 # print("Generate text stream")
 
@@ -78,27 +61,79 @@ class GenerateWrapper:
         self.tracer = tracer
 
     def generate(self, *args: Any, **kwargs: Any) -> Any:
+        f_sig = inspect.signature(self.generate_fn)
         with self.tracer.start_as_current_span("text-generate-span") as span:
-            self.tracer.mark_rag_query_trace_event(
-                PromptResolved(
-                    fully_resolved_prompt=json_serialize_anything(
-                        {"args": args, "kwargs": kwargs}
-                    )
-                )
+            input_serializable = _get_serializable_input(f_sig, args, kwargs)
+            span.set_attribute("input", json.dumps(input_serializable))
+            response = self.generate_fn(  # will proably be dict
+                *args, **kwargs
             )
-            raw_response = self.generate_fn(*args, **kwargs)
-            self.tracer.mark_rag_query_trace_event(
-                event=LLMOutputReceived(llm_output="xyz")
+            _try_log_output(span, response)
+
+            self.tracer.add_rag_event_for_span(
+                "generate",
+                span=span,
+                input=input_serializable,
+                output=response,
             )
-            return raw_response
+            return response
+
+
+class GenerateTextWrapper:
+    def __init__(
+        self,
+        generate_text: IBMWatsonXGenerateTextMethod,
+        tracer: LastMileTracer,
+    ):
+        self.generate_text_fn = generate_text
+        self.tracer = tracer
+
+    def generate_text(self, *args: Any, **kwargs: Any) -> Any:
+        f_sig = inspect.signature(self.generate_text_fn)
+        with self.tracer.start_as_current_span("text-generate-span") as span:
+            input_serializable = _get_serializable_input(f_sig, args, kwargs)
+            span.set_attribute("input", json.dumps(input_serializable))
+            response = self.generate_text_fn(  # will proably be str
+                *args, **kwargs
+            )
+            _try_log_output(span, response)
+
+            self.tracer.add_rag_event_for_span(
+                "generate",
+                span=span,
+                input=input_serializable,
+                output=response,
+            )
+            return response
+
+        # with self.tracer.start_as_current_span("text-generate-span") as span:
+
+        #     raw_response = self.generate_fn(*args, **kwargs)
+        #     self.tracer.mark_rag_query_trace_event(
+        #         event=LLMOutputReceived(llm_output="xyz")
+        #     )
+        #     return raw_response
 
 
 class IBMWatsonXModelWrapper(NamedWrapper[Model]):
     def __init__(self, ibm_watsonx_model: Model, tracer: LastMileTracer):
+        super().__init__(ibm_watsonx_model)
         self.ibm_watsonx_model = ibm_watsonx_model
         self.tracer = tracer
 
-        self.generate = GenerateWrapper(ibm_watsonx_model.generate, tracer)  # type: ignore
+        self.generate_fn = GenerateWrapper(
+            ibm_watsonx_model.generate, tracer  # type: ignore
+        ).generate
+        self.generate_text_fn = GenerateTextWrapper(
+            ibm_watsonx_model.generate_text, tracer  # type: ignore
+        ).generate_text
+
+    def generate(self, *args: Any, **kwargs: Any) -> Any:
+        return self.generate_fn(*args, **kwargs)
+
+    def generate_text(self, *args: Any, **kwargs: Any) -> Any:
+        return self.generate_text_fn(*args, **kwargs)
+
         # self.generate_text = GenerateTextWrapper(
         #     ibm_watsonx_model.generate_text, tracer
         # )
@@ -107,5 +142,40 @@ class IBMWatsonXModelWrapper(NamedWrapper[Model]):
         # )
 
 
-def wrap(ibm_watsonx_model: Model, tracer: LastMileTracer):
+def wrap_watson(
+    ibm_watsonx_model: Model, tracer: LastMileTracer
+) -> IBMWatsonXModelWrapper:
+    """
+    Wrapper method around Watson's Model class which adds LastMile tracing to
+    the methods `generate`, `generate_text`, and `generate_text_stream`.
+
+    To use it, wrap it around an existing Model and tracer object like so:
+    ```
+    from ibm_watsonx_ai.foundation_models import Model
+    from ibm_watsonx_ai.metanames import (
+        GenTextParamsMetaNames as GenParams,
+    )
+    from ibm_watsonx_ai.foundation_models.utils.enums import (
+        ModelTypes,
+    )
+    from lastmile_eval.rag.debugger.tracing.auto_instrumentation import (
+        wrap_watson,
+    )
+    from lastmile_eval.rag.debugger.tracing.sdk import get_lastmile_tracer
+
+    tracer = get_lastmile_tracer(<tracer-name>, <lastmile-api-token>)
+    model = Model(
+        model_id=ModelTypes.GRANITE_13B_CHAT_V2,
+        params=generate_params,
+        credentials=dict(
+            api_key=os.getenv("WATSONX_API_KEY"),
+            url="https://us-south.ml.cloud.ibm.com",
+        ),
+        space_id=os.getenv("WATSONX_SPACE_ID"),
+        verify=None,
+        validate=True,
+    )
+    wrapped_model = wrap_watson(tracer, model)
+    ```
+    """
     return IBMWatsonXModelWrapper(ibm_watsonx_model, tracer)

--- a/src/tracing_auto_instrumentation/ibm.py
+++ b/src/tracing_auto_instrumentation/ibm.py
@@ -1,18 +1,14 @@
 import inspect
 import json
-import os
 from abc import abstractmethod
 from typing import Any, Protocol
-import dotenv
 from ibm_watsonx_ai.foundation_models import Model
-from ibm_watsonx_ai.foundation_models.utils.enums import ModelTypes
-from ibm_watsonx_ai.metanames import GenTextParamsMetaNames as GenParams
 from lastmile_eval.rag.debugger.api import LastMileTracer
 from lastmile_eval.rag.debugger.tracing.decorators import (
     _get_serializable_input,
     _try_log_output,
 )
-from lastmile_eval.rag.debugger.tracing.wrap_utils import (
+from .wrap_utils import (
     NamedWrapper,
 )
 

--- a/src/tracing_auto_instrumentation/openai.py
+++ b/src/tracing_auto_instrumentation/openai.py
@@ -433,3 +433,6 @@ def wrap(
         return OpenAIV1Wrapper(openai, tracer)
     else:
         return OpenAIV0Wrapper(openai, tracer)
+
+
+wrap_openai = wrap


### PR DESCRIPTION
[ez] alias for openai wrap for consistency and disambiguation

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/tracing_auto_instrumentation/pull/10).
* __->__ #10
* #9
* #8