### PR TITLE
Migrate Auto-Instrumentation Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,21 @@
 lastmile_eval
+
 ibm-watsonx-ai
 openai
+
+# Integrations with other LLM frameworks
+llama-index
+llama-index-embeddings-openai
+llama-index-readers-web
+llama-index-callbacks-openinference
+openai
+html2text 
+pandas 
+pyarrow 
+tqdm
+openinference-instrumentation-llama-index
+openinference-instrumentation-langchain
+langchain
+langchain_core
+langchain_openai
+ibm_watsonx_ai


### PR DESCRIPTION
Migrate Auto-Instrumentation Requirements

from https://github.com/lastmile-ai/eval/pull/567
