### PR TITLE
OpenAI refactor [4/n]: Support async

### DIFF
--- a/examples/openai_streaming.ipynb
+++ b/examples/openai_streaming.ipynb
@@ -18,7 +18,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 7,
+            "execution_count": 1,
             "id": "80e71f33",
             "metadata": {
                 "pycharm": {
@@ -45,7 +45,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 8,
+            "execution_count": 2,
             "id": "4abf2967",
             "metadata": {},
             "outputs": [
@@ -53,17 +53,12 @@
                     "name": "stderr",
                     "output_type": "stream",
                     "text": [
-                        "2024-05-30 18:37:45,454 - Overriding of current TracerProvider is not allowed\n"
-                    ]
-                },
-                {
-                    "name": "stderr",
-                    "output_type": "stream",
-                    "text": [
-                        "2024-05-30 18:37:45,456 - Starting new HTTPS connection (1): lastmileai.dev:443\n",
-                        "2024-05-30 18:37:45,529 - https://lastmileai.dev:443 \"GET /api/evaluation_projects/list?name=OpenAI+Text+Calling+w.+Streaming HTTP/1.1\" 200 367\n",
-                        "2024-05-30 18:37:45,531 - load_ssl_context verify=True cert=None trust_env=True http2=False\n",
-                        "2024-05-30 18:37:45,531 - load_verify_locations cafile='/opt/homebrew/Caskroom/miniconda/base/envs/eval/lib/python3.12/site-packages/certifi/cacert.pem'\n"
+                        "/opt/homebrew/Caskroom/miniconda/base/envs/eval/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+                        "  from .autonotebook import tqdm as notebook_tqdm\n",
+                        "2024-05-30 19:07:57,651 - Starting new HTTPS connection (1): lastmileai.dev:443\n",
+                        "2024-05-30 19:07:57,778 - https://lastmileai.dev:443 \"GET /api/evaluation_projects/list?name=OpenAI+Text+Calling+w.+Streaming HTTP/1.1\" 200 367\n",
+                        "2024-05-30 19:07:57,780 - load_ssl_context verify=True cert=None trust_env=True http2=False\n",
+                        "2024-05-30 19:07:57,781 - load_verify_locations cafile='/opt/homebrew/Caskroom/miniconda/base/envs/eval/lib/python3.12/site-packages/certifi/cacert.pem'\n"
                     ]
                 }
             ],
@@ -78,14 +73,14 @@
                 "tracer: LastMileTracer = get_lastmile_tracer(\n",
                 "    tracer_name=\"OpenAI Text Calling w. Streaming\",\n",
                 ")\n",
-                "client = openai.OpenAI(api_key=OPENAI_API_KEY)\n",
-                "# client = openai.AsyncOpenAI(api_key=OPENAI_API_KEY)\n",
+                "# client = openai.OpenAI(api_key=OPENAI_API_KEY)\n",
+                "client = openai.AsyncOpenAI(api_key=OPENAI_API_KEY)\n",
                 "client = wrap_openai(client, tracer)"
             ]
         },
         {
             "cell_type": "code",
-            "execution_count": 9,
+            "execution_count": 3,
             "id": "4276d4b0",
             "metadata": {},
             "outputs": [],
@@ -94,7 +89,7 @@
                 "    completion_params = {\n",
                 "        \"model\": \"gpt-3.5-turbo\",\n",
                 "        \"top_p\": 1,\n",
-                "        \"max_tokens\": 3000,\n",
+                "        \"max_tokens\": 10,\n",
                 "        \"temperature\": 1,\n",
                 "        \"stream\": stream,\n",
                 "        \"messages\": [\n",
@@ -116,38 +111,95 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 10,
+            "execution_count": 4,
             "id": "9aa6f3f6",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# # Run your code as usual\n",
+                "# stream = False\n",
+                "# run_my_existing_openai_app(\"Tell me a joke about apples\", stream=stream)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "263685c1",
+            "metadata": {},
+            "source": [
+                "## Time to test this with async calls"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "id": "d2045d18",
             "metadata": {},
             "outputs": [
                 {
                     "name": "stderr",
                     "output_type": "stream",
                     "text": [
-                        "2024-05-30 18:37:45,547 - Request options: {'method': 'post', 'url': '/chat/completions', 'files': None, 'json_data': {'messages': [{'content': 'Tell me a joke about apples', 'role': 'user'}], 'model': 'gpt-3.5-turbo', 'max_tokens': 3000, 'stream': False, 'temperature': 1, 'top_p': 1}}\n",
-                        "2024-05-30 18:37:45,547 - Sending HTTP Request: POST https://api.openai.com/v1/chat/completions\n",
-                        "2024-05-30 18:37:45,548 - connect_tcp.started host='api.openai.com' port=443 local_address=None timeout=5.0 socket_options=None\n",
-                        "2024-05-30 18:37:45,555 - connect_tcp.complete return_value=<httpcore._backends.sync.SyncStream object at 0x32f7c9820>\n",
-                        "2024-05-30 18:37:45,556 - start_tls.started ssl_context=<ssl.SSLContext object at 0x32f7a00d0> server_hostname='api.openai.com' timeout=5.0\n",
-                        "2024-05-30 18:37:45,570 - start_tls.complete return_value=<httpcore._backends.sync.SyncStream object at 0x32f1717f0>\n",
-                        "2024-05-30 18:37:45,571 - send_request_headers.started request=<Request [b'POST']>\n",
-                        "2024-05-30 18:37:45,572 - send_request_headers.complete\n",
-                        "2024-05-30 18:37:45,573 - send_request_body.started request=<Request [b'POST']>\n",
-                        "2024-05-30 18:37:45,573 - send_request_body.complete\n",
-                        "2024-05-30 18:37:45,574 - receive_response_headers.started request=<Request [b'POST']>\n",
-                        "2024-05-30 18:37:46,086 - receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Date', b'Thu, 30 May 2024 22:37:46 GMT'), (b'Content-Type', b'application/json'), (b'Transfer-Encoding', b'chunked'), (b'Connection', b'keep-alive'), (b'openai-organization', b'lastmile-ai'), (b'openai-processing-ms', b'290'), (b'openai-version', b'2020-10-01'), (b'strict-transport-security', b'max-age=15724800; includeSubDomains'), (b'x-ratelimit-limit-requests', b'10000'), (b'x-ratelimit-limit-tokens', b'2000000'), (b'x-ratelimit-remaining-requests', b'9999'), (b'x-ratelimit-remaining-tokens', b'1996992'), (b'x-ratelimit-reset-requests', b'6ms'), (b'x-ratelimit-reset-tokens', b'90ms'), (b'x-request-id', b'req_cd99897b93259fcc4f1dbefeb5ea679c'), (b'CF-Cache-Status', b'DYNAMIC'), (b'Set-Cookie', b'__cf_bm=8fmYyOryZF1WDmyjhIOvNQ2NH8lSv4DhEmuLCYdOPow-1717108666-1.0.1.1-xNgtDMVRxwupgAvaz1MouwyifyCUyTGiCIMJ_kyEERsTy35v__DBf8Ga3S_E9dGSxLFBV.iGPwBg_zUFyU7qgA; path=/; expires=Thu, 30-May-24 23:07:46 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None'), (b'Set-Cookie', b'_cfuvid=H3C.a.KYSgjPQHSSaB52D5WCLJTc2nM69o9Hr12wJ38-1717108666078-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None'), (b'Server', b'cloudflare'), (b'CF-RAY', b'88c235e7dc7e43a1-EWR'), (b'Content-Encoding', b'gzip'), (b'alt-svc', b'h3=\":443\"; ma=86400')])\n",
-                        "2024-05-30 18:37:46,087 - HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
-                        "2024-05-30 18:37:46,088 - receive_response_body.started request=<Request [b'POST']>\n",
-                        "2024-05-30 18:37:46,089 - receive_response_body.complete\n",
-                        "2024-05-30 18:37:46,089 - response_closed.started\n",
-                        "2024-05-30 18:37:46,089 - response_closed.complete\n",
-                        "2024-05-30 18:37:46,090 - HTTP Response: POST https://api.openai.com/v1/chat/completions \"200 OK\" Headers([('date', 'Thu, 30 May 2024 22:37:46 GMT'), ('content-type', 'application/json'), ('transfer-encoding', 'chunked'), ('connection', 'keep-alive'), ('openai-organization', 'lastmile-ai'), ('openai-processing-ms', '290'), ('openai-version', '2020-10-01'), ('strict-transport-security', 'max-age=15724800; includeSubDomains'), ('x-ratelimit-limit-requests', '10000'), ('x-ratelimit-limit-tokens', '2000000'), ('x-ratelimit-remaining-requests', '9999'), ('x-ratelimit-remaining-tokens', '1996992'), ('x-ratelimit-reset-requests', '6ms'), ('x-ratelimit-reset-tokens', '90ms'), ('x-request-id', 'req_cd99897b93259fcc4f1dbefeb5ea679c'), ('cf-cache-status', 'DYNAMIC'), ('set-cookie', '__cf_bm=8fmYyOryZF1WDmyjhIOvNQ2NH8lSv4DhEmuLCYdOPow-1717108666-1.0.1.1-xNgtDMVRxwupgAvaz1MouwyifyCUyTGiCIMJ_kyEERsTy35v__DBf8Ga3S_E9dGSxLFBV.iGPwBg_zUFyU7qgA; path=/; expires=Thu, 30-May-24 23:07:46 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None'), ('set-cookie', '_cfuvid=H3C.a.KYSgjPQHSSaB52D5WCLJTc2nM69o9Hr12wJ38-1717108666078-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None'), ('server', 'cloudflare'), ('cf-ray', '88c235e7dc7e43a1-EWR'), ('content-encoding', 'gzip'), ('alt-svc', 'h3=\":443\"; ma=86400')])\n",
-                        "2024-05-30 18:37:46,090 - request_id: req_cd99897b93259fcc4f1dbefeb5ea679c\n",
-                        "2024-05-30 18:37:46,144 - https://lastmileai.dev:443 \"POST /api/trace/create HTTP/1.1\" 200 10\n",
-                        "2024-05-30 18:37:46,146 - Starting new HTTPS connection (1): lastmileai.dev:443\n",
-                        "2024-05-30 18:37:46,228 - https://lastmileai.dev:443 \"POST /api/rag_query_traces/create HTTP/1.1\" 200 475\n",
-                        "2024-05-30 18:37:46,230 - Starting new HTTPS connection (1): lastmileai.dev:443\n",
-                        "2024-05-30 18:37:46,432 - https://lastmileai.dev:443 \"POST /api/rag_events/create HTTP/1.1\" 200 803\n"
+                        "2024-05-30 19:07:57,805 - load_ssl_context verify=True cert=None trust_env=True http2=False\n",
+                        "2024-05-30 19:07:57,806 - load_verify_locations cafile='/opt/homebrew/Caskroom/miniconda/base/envs/eval/lib/python3.12/site-packages/certifi/cacert.pem'\n"
+                    ]
+                }
+            ],
+            "source": [
+                "client = openai.AsyncOpenAI(api_key=OPENAI_API_KEY)\n",
+                "client = wrap_openai(client, tracer)\n",
+                "\n",
+                "async def run_my_existing_openai_app_async(user_message: str, stream: bool = True):\n",
+                "    completion_params = {\n",
+                "        \"model\": \"gpt-3.5-turbo\",\n",
+                "        \"top_p\": 1,\n",
+                "        \"max_tokens\": 3000,\n",
+                "        \"temperature\": 1,\n",
+                "        \"stream\": stream,\n",
+                "        \"messages\": [\n",
+                "            {\n",
+                "                \"content\": user_message,\n",
+                "                \"role\": \"user\",\n",
+                "            }\n",
+                "        ],\n",
+                "    }\n",
+                "\n",
+                "    response = await client.chat.completions.create(**completion_params)\n",
+                "    print(\"Chat Completion Response: \")\n",
+                "    if stream:\n",
+                "        async for chunk in response:\n",
+                "            print(f\"{chunk=}\")\n",
+                "    else:\n",
+                "        print(f\"{response=}\")\n",
+                "    return response"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "id": "f9113e1f",
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "2024-05-30 19:07:57,824 - Request options: {'method': 'post', 'url': '/chat/completions', 'files': None, 'json_data': {'messages': [{'content': 'Tell me a joke about apples', 'role': 'user'}], 'model': 'gpt-3.5-turbo', 'max_tokens': 3000, 'stream': False, 'temperature': 1, 'top_p': 1}}\n",
+                        "2024-05-30 19:07:57,837 - connect_tcp.started host='api.openai.com' port=443 local_address=None timeout=5.0 socket_options=None\n",
+                        "2024-05-30 19:07:57,874 - connect_tcp.complete return_value=<httpcore._backends.anyio.AnyIOStream object at 0x141622390>\n",
+                        "2024-05-30 19:07:57,875 - start_tls.started ssl_context=<ssl.SSLContext object at 0x147aadfd0> server_hostname='api.openai.com' timeout=5.0\n",
+                        "2024-05-30 19:07:57,890 - start_tls.complete return_value=<httpcore._backends.anyio.AnyIOStream object at 0x131a60800>\n",
+                        "2024-05-30 19:07:57,891 - send_request_headers.started request=<Request [b'POST']>\n",
+                        "2024-05-30 19:07:57,891 - send_request_headers.complete\n",
+                        "2024-05-30 19:07:57,892 - send_request_body.started request=<Request [b'POST']>\n",
+                        "2024-05-30 19:07:57,892 - send_request_body.complete\n",
+                        "2024-05-30 19:07:57,892 - receive_response_headers.started request=<Request [b'POST']>\n",
+                        "2024-05-30 19:07:58,421 - receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Date', b'Thu, 30 May 2024 23:07:58 GMT'), (b'Content-Type', b'application/json'), (b'Transfer-Encoding', b'chunked'), (b'Connection', b'keep-alive'), (b'openai-organization', b'lastmile-ai'), (b'openai-processing-ms', b'338'), (b'openai-version', b'2020-10-01'), (b'strict-transport-security', b'max-age=15724800; includeSubDomains'), (b'x-ratelimit-limit-requests', b'10000'), (b'x-ratelimit-limit-tokens', b'2000000'), (b'x-ratelimit-remaining-requests', b'9999'), (b'x-ratelimit-remaining-tokens', b'1996992'), (b'x-ratelimit-reset-requests', b'6ms'), (b'x-ratelimit-reset-tokens', b'90ms'), (b'x-request-id', b'req_1188547de08bbfea1629096806f25429'), (b'CF-Cache-Status', b'DYNAMIC'), (b'Set-Cookie', b'__cf_bm=haiA3zZm1sL7A1Z.b3_33b7bY4Vd2fYcqX.6cPqivEM-1717110478-1.0.1.1-L3zITMUrqgiYlVqPNlCI5Iy.EHhU4ByfJAdeEPoo78IH4Cz1jAGGdlBskxeU72AU2ywcwuXiew.lFBfyFPCc7w; path=/; expires=Thu, 30-May-24 23:37:58 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None'), (b'Set-Cookie', b'_cfuvid=aHgrwv33GVYtAkjJhjQkICwrWyPYBZ7GsvWw7zz9dE0-1717110478444-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None'), (b'Server', b'cloudflare'), (b'CF-RAY', b'88c262271f334233-EWR'), (b'Content-Encoding', b'gzip'), (b'alt-svc', b'h3=\":443\"; ma=86400')])\n",
+                        "2024-05-30 19:07:58,423 - HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+                        "2024-05-30 19:07:58,423 - receive_response_body.started request=<Request [b'POST']>\n",
+                        "2024-05-30 19:07:58,424 - receive_response_body.complete\n",
+                        "2024-05-30 19:07:58,425 - response_closed.started\n",
+                        "2024-05-30 19:07:58,425 - response_closed.complete\n",
+                        "2024-05-30 19:07:58,426 - HTTP Request: POST https://api.openai.com/v1/chat/completions \"200 OK\"\n"
                     ]
                 },
                 {
@@ -155,68 +207,47 @@
                     "output_type": "stream",
                     "text": [
                         "Chat Completion Response: \n",
-                        "response=ChatCompletion(id='chatcmpl-9UigzXwUGWGmfK14LcpVwieaCKM3T', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content=\"Why did the apple go to the doctor? Because it wasn't peeling well!\", role='assistant', function_call=None, tool_calls=None))], created=1717108665, model='gpt-3.5-turbo-0125', object='chat.completion', system_fingerprint=None, usage=CompletionUsage(completion_tokens=17, prompt_tokens=13, total_tokens=30))\n"
+                        "response=ChatCompletion(id='chatcmpl-9UjAEjKQc9Iatqn1JAJ3ALHV7rEOK', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content=\"Why did the apple go to the doctor? Because it wasn't peeling well!\", role='assistant', function_call=None, tool_calls=None))], created=1717110478, model='gpt-3.5-turbo-0125', object='chat.completion', system_fingerprint=None, usage=CompletionUsage(completion_tokens=17, prompt_tokens=13, total_tokens=30))\n"
                     ]
                 },
                 {
-                    "data": {
-                        "text/plain": [
-                            "ChatCompletion(id='chatcmpl-9UigzXwUGWGmfK14LcpVwieaCKM3T', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content=\"Why did the apple go to the doctor? Because it wasn't peeling well!\", role='assistant', function_call=None, tool_calls=None))], created=1717108665, model='gpt-3.5-turbo-0125', object='chat.completion', system_fingerprint=None, usage=CompletionUsage(completion_tokens=17, prompt_tokens=13, total_tokens=30))"
-                        ]
-                    },
-                    "execution_count": 10,
-                    "metadata": {},
-                    "output_type": "execute_result"
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "2024-05-30 19:07:58,440 - Failed to detach context\n",
+                        "Traceback (most recent call last):\n",
+                        "  File \"/opt/homebrew/Caskroom/miniconda/base/envs/eval/lib/python3.12/site-packages/opentelemetry/trace/__init__.py\", line 570, in use_span\n",
+                        "    yield span\n",
+                        "  File \"/opt/homebrew/Caskroom/miniconda/base/envs/eval/lib/python3.12/site-packages/opentelemetry/sdk/trace/__init__.py\", line 1071, in start_as_current_span\n",
+                        "    yield span\n",
+                        "  File \"/Users/rossdancraig/Projects/eval/src/lastmile_eval/rag/debugger/tracing/lastmile_tracer.py\", line 220, in start_as_current_span\n",
+                        "    yield span\n",
+                        "  File \"/Users/rossdancraig/Projects/tracing_auto_instrumentation/src/tracing_auto_instrumentation/openai/openai_wrapper.py\", line 303, in acreate\n",
+                        "    yield raw_response\n",
+                        "GeneratorExit\n",
+                        "\n",
+                        "During handling of the above exception, another exception occurred:\n",
+                        "\n",
+                        "Traceback (most recent call last):\n",
+                        "  File \"/opt/homebrew/Caskroom/miniconda/base/envs/eval/lib/python3.12/site-packages/opentelemetry/context/__init__.py\", line 163, in detach\n",
+                        "    _RUNTIME_CONTEXT.detach(token)  # type: ignore\n",
+                        "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+                        "  File \"/opt/homebrew/Caskroom/miniconda/base/envs/eval/lib/python3.12/site-packages/opentelemetry/context/contextvars_context.py\", line 50, in detach\n",
+                        "    self._current_context.reset(token)  # type: ignore\n",
+                        "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+                        "ValueError: <Token var=<ContextVar name='current_context' default={} at 0x147ae4040> at 0x147481dc0> was created in a different Context\n",
+                        "2024-05-30 19:07:58,444 - Starting new HTTPS connection (1): lastmileai.dev:443\n",
+                        "2024-05-30 19:07:58,523 - https://lastmileai.dev:443 \"POST /api/trace/create HTTP/1.1\" 200 10\n",
+                        "2024-05-30 19:07:58,525 - Starting new HTTPS connection (1): lastmileai.dev:443\n",
+                        "2024-05-30 19:07:58,605 - https://lastmileai.dev:443 \"POST /api/rag_query_traces/create HTTP/1.1\" 200 475\n",
+                        "2024-05-30 19:07:58,607 - Starting new HTTPS connection (1): lastmileai.dev:443\n",
+                        "2024-05-30 19:07:58,697 - https://lastmileai.dev:443 \"POST /api/rag_events/create HTTP/1.1\" 200 804\n"
+                    ]
                 }
             ],
             "source": [
-                "# Run your code as usual\n",
                 "stream = False\n",
-                "run_my_existing_openai_app(\"Tell me a joke about apples\", stream=stream)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 11,
-            "id": "d2045d18",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# async def run_my_existing_openai_app_async(user_message: str, stream: bool = True):\n",
-                "#     completion_params = {\n",
-                "#         \"model\": \"gpt-3.5-turbo\",\n",
-                "#         \"top_p\": 1,\n",
-                "#         \"max_tokens\": 3000,\n",
-                "#         \"temperature\": 1,\n",
-                "#         \"stream\": stream,\n",
-                "#         \"messages\": [\n",
-                "#             {\n",
-                "#                 \"content\": user_message,\n",
-                "#                 \"role\": \"user\",\n",
-                "#             }\n",
-                "#         ],\n",
-                "#     }\n",
-                "\n",
-                "#     response = await client.ChatCompletion.acreate(**completion_params)\n",
-                "#     print(\"Chat Completion Response: \")\n",
-                "#     if stream:\n",
-                "#         for chunk in response:\n",
-                "#             print(f\"{chunk=}\")\n",
-                "#     else:\n",
-                "#         print(f\"{response=}\")\n",
-                "#     return response"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 12,
-            "id": "f9113e1f",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# stream = False\n",
-                "# response = await run_my_existing_openai_app_async(\"Tell me a joke about apples\", stream=stream)\n",
-                "# print(\"God damn it: \", response)"
+                "response = await run_my_existing_openai_app_async(\"Tell me a joke about apples\", stream=stream)"
             ]
         }
     ],


### PR DESCRIPTION
OpenAI refactor [4/n]: Support async

This wasn't supported before, pretty important

I'm able to get async streaming to work just fine when running the notebook, but not able to get able to get async non-streaming 100% error-free. It still works (at least for a singular span) by saving to our PostGres DB and Jaeger collector, just that we get an error saying `Failed to detach context` which I'll need to investigate more later

## Test Plan
Run the notebook

Async streaming
<img width="1147" alt="Screenshot 2024-05-30 at 19 02 23" src="https://github.com/lastmile-ai/tracing_auto_instrumentation/assets/151060367/845e664b-5773-477c-9651-b6d206b53075">


Async non-streaming
<img width="897" alt="Screenshot 2024-05-30 at 19 09 16" src="https://github.com/lastmile-ai/tracing_auto_instrumentation/assets/151060367/c2b73d3a-f669-4bb4-b339-3c9d4b1b7895">
