### PR TITLE
[MNN-36] Explicitly mark that we want to save OTel span events in the auto-instrumentors

### DIFF
--- a/src/tracing_auto_instrumentation/ibm/ibm.py
+++ b/src/tracing_auto_instrumentation/ibm/ibm.py
@@ -81,6 +81,7 @@ class GenerateWrapper:
                 span=span,
                 input=input_serializable,
                 output=response,
+                should_also_save_in_span=True,
             )
             return response
 
@@ -109,6 +110,7 @@ class GenerateTextWrapper:
                 span=span,
                 input=input_serializable,
                 output=response,
+                should_also_save_in_span=True,
             )
             return response
 

--- a/src/tracing_auto_instrumentation/langchain/langchain_instrumentor.py
+++ b/src/tracing_auto_instrumentation/langchain/langchain_instrumentor.py
@@ -11,7 +11,6 @@ from openinference.instrumentation.langchain._tracer import (
 from openinference.instrumentation.langchain.package import _instruments
 from openinference.instrumentation.langchain.version import __version__
 from opentelemetry import context as context_api
-from opentelemetry import trace as trace_api
 from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.sdk.trace import Span
 from opentelemetry.instrumentation.instrumentor import (
@@ -20,7 +19,8 @@ from opentelemetry.instrumentation.instrumentor import (
 from wrapt import wrap_function_wrapper
 
 # TODO: Fix typing
-from lastmile_eval.rag.debugger.tracing.sdk import get_lastmile_tracer
+from lastmile_eval.rag.debugger.api import LastMileTracer
+from lastmile_eval.rag.debugger.tracing import get_lastmile_tracer
 
 from lastmile_eval.rag.debugger.common.utils import (
     LASTMILE_SPAN_KIND_KEY_NAME,
@@ -50,7 +50,7 @@ class LangChainInstrumentor(BaseInstrumentor):
         lastmile_api_token: Optional[str] = None,
     ) -> None:
         super().__init__()
-        self._tracer = get_lastmile_tracer(
+        self._tracer: LastMileTracer = get_lastmile_tracer(
             tracer_name=project_name
             or (DEFAULT_TRACER_NAME_PREFIX + " - Langchain"),
             lastmile_api_token=lastmile_api_token,
@@ -108,6 +108,7 @@ class _LastMileLangChainTracer(OpenInferenceTracer):
                         event_name=span_kind,
                         span=span,
                         event_data=serializable_payload,
+                        should_also_save_in_span=True,
                     )
                 span.set_attribute(LASTMILE_SPAN_KIND_KEY_NAME, span_kind)
 
@@ -123,7 +124,7 @@ class _BaseCallbackManagerInit:
     __slots__ = ("_tracer", "_cls")
 
     def __init__(
-        self, tracer: trace_api.Tracer, cls: Type[_LastMileLangChainTracer]
+        self, tracer: LastMileTracer, cls: Type[_LastMileLangChainTracer]
     ):
         self._tracer = tracer
         self._cls = cls

--- a/src/tracing_auto_instrumentation/llama_index/llama_index_callback_handler.py
+++ b/src/tracing_auto_instrumentation/llama_index/llama_index_callback_handler.py
@@ -2,6 +2,9 @@ import logging
 from time import time_ns
 from typing import Any, Dict, Optional
 
+from lastmile_eval.rag.debugger.api import LastMileTracer
+from lastmile_eval.rag.debugger.common.utils import LASTMILE_SPAN_KIND_KEY_NAME
+from lastmile_eval.rag.debugger.tracing import get_lastmile_tracer
 from llama_index.core.callbacks import CBEventType, EventPayload
 from openinference.instrumentation.llama_index._callback import (
     OpenInferenceTraceCallbackHandler,
@@ -31,14 +34,10 @@ from openinference.instrumentation.llama_index._callback import (
     # LLM_INPUT_MESSAGES,
     # LLM_OUTPUT_MESSAGES,
 )
-from opentelemetry.sdk.trace import ReadableSpan
-from opentelemetry import trace as trace_api
 from opentelemetry import context as context_api
+from opentelemetry import trace as trace_api
 from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY  # type: ignore
-from lastmile_eval.rag.debugger.tracing import get_lastmile_tracer
-from lastmile_eval.rag.debugger.common.utils import (
-    LASTMILE_SPAN_KIND_KEY_NAME,
-)
+from opentelemetry.sdk.trace import ReadableSpan
 
 from ..utils import DEFAULT_TRACER_NAME_PREFIX
 
@@ -81,7 +80,7 @@ class LlamaIndexCallbackHandler(OpenInferenceTraceCallbackHandler):
         project_name: Optional[str] = None,
         lastmile_api_token: Optional[str] = None,
     ):
-        tracer = get_lastmile_tracer(
+        tracer: LastMileTracer = get_lastmile_tracer(
             tracer_name=project_name
             or (DEFAULT_TRACER_NAME_PREFIX + " - LlamaIndex"),
             lastmile_api_token=lastmile_api_token,
@@ -153,7 +152,7 @@ class LlamaIndexCallbackHandler(OpenInferenceTraceCallbackHandler):
 
 def _finish_tracing(
     event_data: _EventData,
-    tracer,
+    tracer: LastMileTracer,
     event_type: CBEventType,
 ) -> None:
     if not (span := event_data.span):
@@ -199,10 +198,11 @@ def _finish_tracing(
                 event_name=str(event_data.event_type),
                 span=span,
                 event_data=serializable_payload,
+                should_also_save_in_span=True,
             )
             tracer.register_params(
                 params=serializable_payload,
-                should_also_save_in_span=False,
+                should_also_save_in_span=True,
                 span=span,
             )
 

--- a/src/tracing_auto_instrumentation/openai/openai_wrapper.py
+++ b/src/tracing_auto_instrumentation/openai/openai_wrapper.py
@@ -586,10 +586,12 @@ def _add_rag_event_with_output(
             span,  # type: ignore
             input=input,
             output=output,
+            should_also_save_in_span=True,
         )
     else:
         tracer.add_rag_event_for_span(
             event_name,
             span,  # type: ignore
             event_data=event_data,
+            should_also_save_in_span=True,
         )


### PR DESCRIPTION
[MNN-36] Explicitly mark that we want to save OTel span events in the auto-instrumentors

Functionality for saving span events when we invoke `add_rag_event_for_span()` was added in https://github.com/lastmile-ai/eval/pull/617. We decided to save this data into the OpenTelemetry span event itself, in order to make the UI consistent and easier to parse information. Setting this argument to true has no functional changes, but it makes it clear that this is an explicit decision and not something that is dependent on how the default implementation works


Pls see comment thread in this PR for context
