### PR TITLE
Process embedding events in LlamaIndex

### DIFF
--- a/src/tracing_auto_instrumentation/llama_index/llama_index_callback_handler.py
+++ b/src/tracing_auto_instrumentation/llama_index/llama_index_callback_handler.py
@@ -3,7 +3,11 @@ from collections import defaultdict
 from time import time_ns
 from typing import Any, Dict, Optional, Union
 
-from lastmile_eval.rag.debugger.api import LastMileTracer, RetrievedNode
+from lastmile_eval.rag.debugger.api import (
+    LastMileTracer,
+    RetrievedNode,
+    TextEmbedding,
+)
 from lastmile_eval.rag.debugger.common.utils import LASTMILE_SPAN_KIND_KEY_NAME
 from lastmile_eval.rag.debugger.tracing import get_lastmile_tracer
 from llama_index.core.callbacks import CBEventType, EventPayload
@@ -16,6 +20,7 @@ from openinference.instrumentation.llama_index._callback import (
     _EventData,  # type: ignore
     # Opinionated params we explicit want to save, see source for full list
     DOCUMENT_SCORE,
+    EMBEDDING_EMBEDDINGS,
     EMBEDDING_MODEL_NAME,
     INPUT_VALUE,
     LLM_INVOCATION_PARAMETERS,
@@ -47,6 +52,7 @@ logger.addHandler(logging.NullHandler())
 
 PARAM_SET_SUBSTRING_MATCHES = (
     DOCUMENT_SCORE,
+    EMBEDDING_EMBEDDINGS,
     EMBEDDING_MODEL_NAME,
     INPUT_VALUE,
     LLM_INVOCATION_PARAMETERS,
@@ -246,6 +252,63 @@ def _finish_tracing(
                     span=span,
                     should_also_save_in_span=True,
                 )
+            elif event_type == CBEventType.EMBEDDING:
+                # embed_info contains as key the index of the text chunk
+                # (or query) and value the embedding info
+                # Example: {0: {'text': 'something to embed', 'vector': [0.1, 0.2, 0.3 ... 0.2343]}}
+                embed_info: defaultdict[
+                    int, dict[str, Union[str, list[float]]]
+                ] = defaultdict(dict)
+                model_name: str = ""
+                for key, value in serializable_payload.items():
+                    if EMBEDDING_EMBEDDINGS in key:
+                        # Example of key would be "embedding.embeddings.0.embedding.text"
+                        key_parts = key.split(".")
+                        text_index: int = -1
+                        for part in key_parts:
+                            if part.isnumeric():
+                                text_index = int(part)
+                        if text_index == -1:
+                            continue
+
+                        # info will be either "text", or "vector"
+                        info_type = key.split(".")[-1]
+                        embed_info[text_index][info_type] = value
+                    if EMBEDDING_MODEL_NAME in key:
+                        model_name = value
+
+                # build list of embeddings
+                embeddings: list[TextEmbedding] = []
+                for key, info_dict in dict(sorted(embed_info.items())).items():
+                    embeddings.append(
+                        TextEmbedding(
+                            id=f"embedding-{key}",
+                            text=str(info_dict["text"]),
+                            vector=list(info_dict["vector"]),  # type: ignore
+                        )
+                    )
+
+                if len(embeddings) == 1:
+                    tracer.add_embedding_event(
+                        embedding=embeddings[0],
+                        span=span,
+                        should_also_save_in_span=True,
+                        metadata={
+                            f"{EMBEDDING_MODEL_NAME}": model_name,
+                        },
+                    )
+                elif len(embeddings) > 1:
+                    curr_span_index: str = span._name[0]
+                    span.update_name(f"{curr_span_index} - multi_embedding")
+                    tracer.add_multi_embedding_event(
+                        embeddings=embeddings,
+                        span=span,
+                        should_also_save_in_span=True,
+                        metadata={
+                            "embedding.count": len(embed_info),
+                            f"{EMBEDDING_MODEL_NAME}": model_name,
+                        },
+                    )
             else:
                 tracer.add_rag_event_for_span(
                     event_name=str(event_data.event_type),
@@ -301,9 +364,9 @@ def _add_rag_event_to_tracer() -> None:
     Done
     QUERY = "query"
     RETRIEVE = "retrieve"
+    EMBEDDING = "embedding"
 
     TODO
-    EMBEDDING = "embedding"
     LLM = "llm"
     SUB_QUESTION = "sub_question"
     TEMPLATING = "templating"


### PR DESCRIPTION
Process embedding events in LlamaIndex

This is somewhat tricky because embedding is used in BOTH ingestion and retrieval stages

In ingestion, it takes on multiple chunks while in query, it just takes user input query.

Because it can take multiple chunks in ingestion, I needed to therefore wrap each embedding call around a synthesize event becuase we only allow one event per span (perhaps something we may want to look into later but not critical for RC1 now)

## Test Plan

### Ingestion

Before: http://44.222.237.105:16686/trace/583f9b2d4558e3f5d501408ff7b877bb

<img width="1908" alt="Screenshot 2024-06-11 at 16 13 26" src="https://github.com/lastmile-ai/tracing_auto_instrumentation/assets/151060367/c77ffd70-59f2-4263-a4f4-1256a6015f6c">


After: http://44.222.237.105:16686/trace/03672017ae35dd5c7db4b4f8316be39b

<img width="1917" alt="Screenshot 2024-06-11 at 16 31 09" src="https://github.com/lastmile-ai/tracing_auto_instrumentation/assets/151060367/48bd2a7b-ef73-474c-b196-95ce0c4444cd">


### Query

Before: http://44.222.237.105:16686/trace/652dd6d8c3be94223202d5826b5584da

<img width="1913" alt="Screenshot 2024-06-11 at 16 12 37" src="https://github.com/lastmile-ai/tracing_auto_instrumentation/assets/151060367/1c5b3b66-c693-4853-9e64-4851137dec37">


After: http://44.222.237.105:16686/trace/a32935403ba57839eeaff6dc63c4cef0

<img width="1911" alt="Screenshot 2024-06-11 at 16 32 43" src="https://github.com/lastmile-ai/tracing_auto_instrumentation/assets/151060367/385241aa-967e-4198-9ed5-5a010bc28666">

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/tracing_auto_instrumentation/pull/44).
* #45
* __->__ #44
* #43