### PR TITLE
[1/n] Add ToolCall event to LlamaIndex: Fork query output from function call output

### DIFF
--- a/examples/llama_index_function_calls.ipynb
+++ b/examples/llama_index_function_calls.ipynb
@@ -1,0 +1,229 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install llama-index-agent-openai\n",
+    "%pip install llama-index-llms-openai\n",
+    "!pip install \"tracing-auto-instrumentation[llama-index]\" --upgrade"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import llama_index.core\n",
+    "\n",
+    "from tracing_auto_instrumentation.llama_index import LlamaIndexCallbackHandler\n",
+    "llama_index.core.global_handler = LlamaIndexCallbackHandler(\n",
+    "    project_name=\"Function call demo\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OpenAI API key configured\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index.agent.openai import OpenAIAgent\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "from llama_index.core.tools import FunctionTool\n",
+    "\n",
+    "import os\n",
+    "import dotenv\n",
+    "from getpass import getpass\n",
+    "\n",
+    "dotenv.load_dotenv()\n",
+    "if os.getenv(\"OPENAI_API_KEY\") is None:\n",
+    "    os.environ[\"OPENAI_API_KEY\"] = getpass(\n",
+    "        \"Paste your OpenAI key from:\"\n",
+    "        \" https://platform.openai.com/account/api-keys\\n\"\n",
+    "    )\n",
+    "assert os.getenv(\"OPENAI_API_KEY\", \"\").startswith(\n",
+    "    \"sk-\"\n",
+    "), \"This doesn't look like a valid OpenAI API key\"\n",
+    "print(\"OpenAI API key configured\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def multiply(a: int, b: int) -> int:\n",
+    "    \"\"\"Multiple two integers and returns the result integer\"\"\"\n",
+    "    return a * b\n",
+    "\n",
+    "\n",
+    "multiply_tool = FunctionTool.from_defaults(fn=multiply)\n",
+    "\n",
+    "def add(a: int, b: int) -> int:\n",
+    "    \"\"\"Add two integers and returns the result integer\"\"\"\n",
+    "    return a + b\n",
+    "\n",
+    "\n",
+    "add_tool = FunctionTool.from_defaults(fn=add)\n",
+    "\n",
+    "llm = OpenAI(model=\"gpt-3.5-turbo-1106\")\n",
+    "agent = OpenAIAgent.from_tools(\n",
+    "    [multiply_tool, add_tool], llm=llm, verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[DEBUG] 2024-06-12 16:30:06,610 _config.py:80: load_ssl_context verify=True cert=None trust_env=True http2=False\n",
+      "[DEBUG] 2024-06-12 16:30:06,610 _config.py:146: load_verify_locations cafile='/opt/homebrew/Caskroom/miniconda/base/envs/eval/lib/python3.12/site-packages/certifi/cacert.pem'\n",
+      "[DEBUG] 2024-06-12 16:30:06,618 _base_client.py:446: Request options: {'method': 'post', 'url': '/chat/completions', 'files': None, 'json_data': {'messages': [{'role': 'user', 'content': 'What is (121 * 3) + 42?'}], 'model': 'gpt-3.5-turbo-1106', 'stream': False, 'temperature': 0.1, 'tool_choice': 'auto', 'tools': [{'type': 'function', 'function': {'name': 'multiply', 'description': 'multiply(a: int, b: int) -> int\\nMultiple two integers and returns the result integer', 'parameters': {'type': 'object', 'properties': {'a': {'title': 'A', 'type': 'integer'}, 'b': {'title': 'B', 'type': 'integer'}}, 'required': ['a', 'b']}}}, {'type': 'function', 'function': {'name': 'add', 'description': 'add(a: int, b: int) -> int\\nAdd two integers and returns the result integer', 'parameters': {'type': 'object', 'properties': {'a': {'title': 'A', 'type': 'integer'}, 'b': {'title': 'B', 'type': 'integer'}}, 'required': ['a', 'b']}}}]}}\n",
+      "[DEBUG] 2024-06-12 16:30:06,629 _base_client.py:949: Sending HTTP Request: POST https://api.openai.com/v1/chat/completions\n",
+      "[DEBUG] 2024-06-12 16:30:06,630 _trace.py:45: connect_tcp.started host='api.openai.com' port=443 local_address=None timeout=60.0 socket_options=None\n",
+      "[DEBUG] 2024-06-12 16:30:06,660 _trace.py:45: connect_tcp.complete return_value=<httpcore._backends.sync.SyncStream object at 0x33ae4f950>\n",
+      "[DEBUG] 2024-06-12 16:30:06,661 _trace.py:45: start_tls.started ssl_context=<ssl.SSLContext object at 0x33aebb8d0> server_hostname='api.openai.com' timeout=60.0\n",
+      "[DEBUG] 2024-06-12 16:30:06,674 _trace.py:45: start_tls.complete return_value=<httpcore._backends.sync.SyncStream object at 0x33a83f2c0>\n",
+      "[DEBUG] 2024-06-12 16:30:06,674 _trace.py:45: send_request_headers.started request=<Request [b'POST']>\n",
+      "[DEBUG] 2024-06-12 16:30:06,675 _trace.py:45: send_request_headers.complete\n",
+      "[DEBUG] 2024-06-12 16:30:06,675 _trace.py:45: send_request_body.started request=<Request [b'POST']>\n",
+      "[DEBUG] 2024-06-12 16:30:06,675 _trace.py:45: send_request_body.complete\n",
+      "[DEBUG] 2024-06-12 16:30:06,676 _trace.py:45: receive_response_headers.started request=<Request [b'POST']>\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Added user message to memory: What is (121 * 3) + 42?\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[DEBUG] 2024-06-12 16:30:07,923 _trace.py:45: receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Date', b'Wed, 12 Jun 2024 20:30:07 GMT'), (b'Content-Type', b'application/json'), (b'Transfer-Encoding', b'chunked'), (b'Connection', b'keep-alive'), (b'openai-organization', b'lastmile-ai'), (b'openai-processing-ms', b'844'), (b'openai-version', b'2020-10-01'), (b'strict-transport-security', b'max-age=15724800; includeSubDomains'), (b'x-ratelimit-limit-requests', b'10000'), (b'x-ratelimit-limit-tokens', b'2000000'), (b'x-ratelimit-remaining-requests', b'9999'), (b'x-ratelimit-remaining-tokens', b'1999977'), (b'x-ratelimit-reset-requests', b'6ms'), (b'x-ratelimit-reset-tokens', b'0s'), (b'x-request-id', b'req_1abeb954219dc0c44b8bdae5212c57c2'), (b'CF-Cache-Status', b'DYNAMIC'), (b'Set-Cookie', b'__cf_bm=bqxfstpty_lTtTYsX2bjwsi1HAHdWO1VSCi3yjB8vk0-1718224207-1.0.1.1-1yXSkXQMqcnEHzlz8TDdzEsiLrAjqXOYV2fIzVl3gQHMdCBOTwBn9U5cy8BWCV8PEB82OqMxrfhyOLjn9UQuiA; path=/; expires=Wed, 12-Jun-24 21:00:07 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None'), (b'Set-Cookie', b'_cfuvid=YEUGtXm9fGTVx6bl.v.4fg_GPtKhCrd57.W2vUetQSA-1718224207871-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None'), (b'Server', b'cloudflare'), (b'CF-RAY', b'892c98cbec957cb2-EWR'), (b'Content-Encoding', b'gzip'), (b'alt-svc', b'h3=\":443\"; ma=86400')])\n",
+      "[INFO] 2024-06-12 16:30:07,925 _client.py:1026: HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "[DEBUG] 2024-06-12 16:30:07,925 _trace.py:45: receive_response_body.started request=<Request [b'POST']>\n",
+      "[DEBUG] 2024-06-12 16:30:07,926 _trace.py:45: receive_response_body.complete\n",
+      "[DEBUG] 2024-06-12 16:30:07,926 _trace.py:45: response_closed.started\n",
+      "[DEBUG] 2024-06-12 16:30:07,927 _trace.py:45: response_closed.complete\n",
+      "[DEBUG] 2024-06-12 16:30:07,927 _base_client.py:988: HTTP Response: POST https://api.openai.com/v1/chat/completions \"200 OK\" Headers([('date', 'Wed, 12 Jun 2024 20:30:07 GMT'), ('content-type', 'application/json'), ('transfer-encoding', 'chunked'), ('connection', 'keep-alive'), ('openai-organization', 'lastmile-ai'), ('openai-processing-ms', '844'), ('openai-version', '2020-10-01'), ('strict-transport-security', 'max-age=15724800; includeSubDomains'), ('x-ratelimit-limit-requests', '10000'), ('x-ratelimit-limit-tokens', '2000000'), ('x-ratelimit-remaining-requests', '9999'), ('x-ratelimit-remaining-tokens', '1999977'), ('x-ratelimit-reset-requests', '6ms'), ('x-ratelimit-reset-tokens', '0s'), ('x-request-id', 'req_1abeb954219dc0c44b8bdae5212c57c2'), ('cf-cache-status', 'DYNAMIC'), ('set-cookie', '__cf_bm=bqxfstpty_lTtTYsX2bjwsi1HAHdWO1VSCi3yjB8vk0-1718224207-1.0.1.1-1yXSkXQMqcnEHzlz8TDdzEsiLrAjqXOYV2fIzVl3gQHMdCBOTwBn9U5cy8BWCV8PEB82OqMxrfhyOLjn9UQuiA; path=/; expires=Wed, 12-Jun-24 21:00:07 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None'), ('set-cookie', '_cfuvid=YEUGtXm9fGTVx6bl.v.4fg_GPtKhCrd57.W2vUetQSA-1718224207871-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None'), ('server', 'cloudflare'), ('cf-ray', '892c98cbec957cb2-EWR'), ('content-encoding', 'gzip'), ('alt-svc', 'h3=\":443\"; ma=86400')])\n",
+      "[DEBUG] 2024-06-12 16:30:07,928 _base_client.py:996: request_id: req_1abeb954219dc0c44b8bdae5212c57c2\n",
+      "[DEBUG] 2024-06-12 16:30:07,937 connectionpool.py:1055: Starting new HTTPS connection (1): lastmileai.dev:443\n",
+      "[DEBUG] 2024-06-12 16:30:08,032 connectionpool.py:549: https://lastmileai.dev:443 \"POST /api/trace/create HTTP/1.1\" 200 10\n",
+      "[DEBUG] 2024-06-12 16:30:08,086 connectionpool.py:549: https://lastmileai.dev:443 \"POST /api/trace/create HTTP/1.1\" 200 10\n",
+      "[DEBUG] 2024-06-12 16:30:08,124 connectionpool.py:549: https://lastmileai.dev:443 \"POST /api/trace/create HTTP/1.1\" 200 10\n",
+      "[DEBUG] 2024-06-12 16:30:08,130 _base_client.py:446: Request options: {'method': 'post', 'url': '/chat/completions', 'files': None, 'json_data': {'messages': [{'role': 'user', 'content': 'What is (121 * 3) + 42?'}, {'role': 'assistant', 'content': None, 'tool_calls': [{'id': 'call_7fCf8kThgr8eJQMc0mR8KWLu', 'function': {'arguments': '{\"a\": 121, \"b\": 3}', 'name': 'multiply'}, 'type': 'function'}, {'id': 'call_CUnxWi0svGT2xDGYPf1eEOq5', 'function': {'arguments': '{\"a\": 363, \"b\": 42}', 'name': 'add'}, 'type': 'function'}]}, {'role': 'tool', 'content': '363', 'name': 'multiply', 'tool_call_id': 'call_7fCf8kThgr8eJQMc0mR8KWLu'}, {'role': 'tool', 'content': '405', 'name': 'add', 'tool_call_id': 'call_CUnxWi0svGT2xDGYPf1eEOq5'}], 'model': 'gpt-3.5-turbo-1106', 'stream': False, 'temperature': 0.1, 'tool_choice': 'auto', 'tools': [{'type': 'function', 'function': {'name': 'multiply', 'description': 'multiply(a: int, b: int) -> int\\nMultiple two integers and returns the result integer', 'parameters': {'type': 'object', 'properties': {'a': {'title': 'A', 'type': 'integer'}, 'b': {'title': 'B', 'type': 'integer'}}, 'required': ['a', 'b']}}}, {'type': 'function', 'function': {'name': 'add', 'description': 'add(a: int, b: int) -> int\\nAdd two integers and returns the result integer', 'parameters': {'type': 'object', 'properties': {'a': {'title': 'A', 'type': 'integer'}, 'b': {'title': 'B', 'type': 'integer'}}, 'required': ['a', 'b']}}}]}}\n",
+      "[DEBUG] 2024-06-12 16:30:08,131 _base_client.py:949: Sending HTTP Request: POST https://api.openai.com/v1/chat/completions\n",
+      "[DEBUG] 2024-06-12 16:30:08,131 _trace.py:45: send_request_headers.started request=<Request [b'POST']>\n",
+      "[DEBUG] 2024-06-12 16:30:08,132 _trace.py:45: send_request_headers.complete\n",
+      "[DEBUG] 2024-06-12 16:30:08,132 _trace.py:45: send_request_body.started request=<Request [b'POST']>\n",
+      "[DEBUG] 2024-06-12 16:30:08,133 _trace.py:45: send_request_body.complete\n",
+      "[DEBUG] 2024-06-12 16:30:08,133 _trace.py:45: receive_response_headers.started request=<Request [b'POST']>\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Calling Function ===\n",
+      "Calling function: multiply with args: {\"a\": 121, \"b\": 3}\n",
+      "Got output: 363\n",
+      "========================\n",
+      "\n",
+      "=== Calling Function ===\n",
+      "Calling function: add with args: {\"a\": 363, \"b\": 42}\n",
+      "Got output: 405\n",
+      "========================\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[DEBUG] 2024-06-12 16:30:09,255 _trace.py:45: receive_response_headers.complete return_value=(b'HTTP/1.1', 200, b'OK', [(b'Date', b'Wed, 12 Jun 2024 20:30:09 GMT'), (b'Content-Type', b'application/json'), (b'Transfer-Encoding', b'chunked'), (b'Connection', b'keep-alive'), (b'openai-organization', b'lastmile-ai'), (b'openai-processing-ms', b'696'), (b'openai-version', b'2020-10-01'), (b'strict-transport-security', b'max-age=15724800; includeSubDomains'), (b'x-ratelimit-limit-requests', b'10000'), (b'x-ratelimit-limit-tokens', b'2000000'), (b'x-ratelimit-remaining-requests', b'9999'), (b'x-ratelimit-remaining-tokens', b'1999971'), (b'x-ratelimit-reset-requests', b'6ms'), (b'x-ratelimit-reset-tokens', b'0s'), (b'x-request-id', b'req_84ddc098548fcfb22ffc50e3e19883c5'), (b'CF-Cache-Status', b'DYNAMIC'), (b'Server', b'cloudflare'), (b'CF-RAY', b'892c98d4fa797cb2-EWR'), (b'Content-Encoding', b'gzip'), (b'alt-svc', b'h3=\":443\"; ma=86400')])\n",
+      "[INFO] 2024-06-12 16:30:09,256 _client.py:1026: HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n",
+      "[DEBUG] 2024-06-12 16:30:09,256 _trace.py:45: receive_response_body.started request=<Request [b'POST']>\n",
+      "[DEBUG] 2024-06-12 16:30:09,257 _trace.py:45: receive_response_body.complete\n",
+      "[DEBUG] 2024-06-12 16:30:09,257 _trace.py:45: response_closed.started\n",
+      "[DEBUG] 2024-06-12 16:30:09,258 _trace.py:45: response_closed.complete\n",
+      "[DEBUG] 2024-06-12 16:30:09,258 _base_client.py:988: HTTP Response: POST https://api.openai.com/v1/chat/completions \"200 OK\" Headers({'date': 'Wed, 12 Jun 2024 20:30:09 GMT', 'content-type': 'application/json', 'transfer-encoding': 'chunked', 'connection': 'keep-alive', 'openai-organization': 'lastmile-ai', 'openai-processing-ms': '696', 'openai-version': '2020-10-01', 'strict-transport-security': 'max-age=15724800; includeSubDomains', 'x-ratelimit-limit-requests': '10000', 'x-ratelimit-limit-tokens': '2000000', 'x-ratelimit-remaining-requests': '9999', 'x-ratelimit-remaining-tokens': '1999971', 'x-ratelimit-reset-requests': '6ms', 'x-ratelimit-reset-tokens': '0s', 'x-request-id': 'req_84ddc098548fcfb22ffc50e3e19883c5', 'cf-cache-status': 'DYNAMIC', 'server': 'cloudflare', 'cf-ray': '892c98d4fa797cb2-EWR', 'content-encoding': 'gzip', 'alt-svc': 'h3=\":443\"; ma=86400'})\n",
+      "[DEBUG] 2024-06-12 16:30:09,259 _base_client.py:996: request_id: req_84ddc098548fcfb22ffc50e3e19883c5\n",
+      "[DEBUG] 2024-06-12 16:30:09,299 connectionpool.py:549: https://lastmileai.dev:443 \"POST /api/trace/create HTTP/1.1\" 200 10\n",
+      "[DEBUG] 2024-06-12 16:30:09,339 connectionpool.py:549: https://lastmileai.dev:443 \"POST /api/trace/create HTTP/1.1\" 200 10\n",
+      "[DEBUG] 2024-06-12 16:30:09,341 connectionpool.py:1055: Starting new HTTPS connection (1): lastmileai.dev:443\n",
+      "[DEBUG] 2024-06-12 16:30:09,423 connectionpool.py:549: https://lastmileai.dev:443 \"POST /api/rag_query_traces/create HTTP/1.1\" 200 None\n",
+      "[DEBUG] 2024-06-12 16:30:09,425 connectionpool.py:1055: Starting new HTTPS connection (1): lastmileai.dev:443\n",
+      "[DEBUG] 2024-06-12 16:30:09,505 connectionpool.py:549: https://lastmileai.dev:443 \"POST /api/rag_events/create HTTP/1.1\" 200 989\n",
+      "[DEBUG] 2024-06-12 16:30:09,507 connectionpool.py:1055: Starting new HTTPS connection (1): lastmileai.dev:443\n",
+      "[DEBUG] 2024-06-12 16:30:09,575 connectionpool.py:549: https://lastmileai.dev:443 \"POST /api/rag_events/create HTTP/1.1\" 200 482\n",
+      "[DEBUG] 2024-06-12 16:30:09,577 connectionpool.py:1055: Starting new HTTPS connection (1): lastmileai.dev:443\n",
+      "[DEBUG] 2024-06-12 16:30:09,781 connectionpool.py:549: https://lastmileai.dev:443 \"POST /api/rag_events/create HTTP/1.1\" 200 477\n",
+      "[DEBUG] 2024-06-12 16:30:09,783 connectionpool.py:1055: Starting new HTTPS connection (1): lastmileai.dev:443\n",
+      "[DEBUG] 2024-06-12 16:30:09,857 connectionpool.py:549: https://lastmileai.dev:443 \"POST /api/rag_events/create HTTP/1.1\" 200 710\n",
+      "[DEBUG] 2024-06-12 16:30:09,860 connectionpool.py:1055: Starting new HTTPS connection (1): lastmileai.dev:443\n",
+      "[DEBUG] 2024-06-12 16:30:10,066 connectionpool.py:549: https://lastmileai.dev:443 \"POST /api/rag_events/create HTTP/1.1\" 200 585\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The result of (121 * 3) is 363, and when you add 42 to it, you get 405.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Note: if you have a APIConnectionError and are on a Mac Silicon device,\n",
+    "# you may need to run the following command in your terminal:\n",
+    "# bash /Applications/Python*/Install\\ Certificates.command\n",
+    "\n",
+    "# After running the command above, please restart this notebook and try again\n",
+    "\n",
+    "response = agent.chat(\"What is (121 * 3) + 42?\")\n",
+    "print(str(response))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
[1/n] Add ToolCall event to LlamaIndex: Fork query output from function call output

K this is really annoying and complicated, have to have separate forking first between a query result vs. a tool call result.

1. Query --> output.value is always a str. See example in http://44.222.237.105:16686/trace/0b8a293810df789ad8e626ebd29a4368 for more details
2. Tool Call --> ordering is llm (call a tool call operation, return the output as `dict["tool_calls: list[json.dump(tool_call_obj) as str]]`) --> tool_call (select a tool/function to use) --> llm (call the input with the tool_call implementation and return the output as str). See example in http://44.222.237.105:16686/trace/5c7123d4fcb4f1d198558679d768243f for more details

## Test Plan

### Function call final output
I added original function call notebook for llama index in https://github.com/lastmile-ai/eval/pull/514, but it got deleted, let's make sure to keep it so we can keep testing stuff

Before (notice that last llm call failed to save a span event): http://44.222.237.105:16686/trace/a56956a64e52087a133539f570b7ece0

<img width="1915" alt="Screenshot 2024-06-12 at 16 32 18" src="https://github.com/lastmile-ai/tracing_auto_instrumentation/assets/151060367/030bd225-b35b-4b8d-8507-f69c5f6bcfdd">


After: (note that last llm call now has an event saved to it): http://44.222.237.105:16686/trace/5c7123d4fcb4f1d198558679d768243f

<img width="1914" alt="Screenshot 2024-06-12 at 16 32 05" src="https://github.com/lastmile-ai/tracing_auto_instrumentation/assets/151060367/0a578987-c9c8-46c4-b789-0b946ae253f4">

### Regular query
No functional changes, check that running the `llama_index.ipynb` notebook still work: http://44.222.237.105:16686/trace/0b8a293810df789ad8e626ebd29a4368
