### PR TITLE
Add get_tracer to langchain and llamaindex instrumentors

### DIFF
--- a/src/tracing_auto_instrumentation/langchain/langchain_instrumentor.py
+++ b/src/tracing_auto_instrumentation/langchain/langchain_instrumentor.py
@@ -57,6 +57,9 @@ class LangChainInstrumentor(BaseInstrumentor):
             project_name=project_name,
         )
 
+    def get_tracer(self) -> LastMileTracer:
+        return self._tracer
+
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 

--- a/src/tracing_auto_instrumentation/llama_index/llama_index_callback_handler.py
+++ b/src/tracing_auto_instrumentation/llama_index/llama_index_callback_handler.py
@@ -90,6 +90,9 @@ class LlamaIndexCallbackHandler(OpenInferenceTraceCallbackHandler):
         )
         super().__init__(tracer)
 
+    def get_tracer(self) -> LastMileTracer:
+        return self._tracer
+
     def on_event_end(
         self,
         event_type: CBEventType,


### PR DESCRIPTION
Add get_tracer to langchain and llamaindex instrumentors

Allow getting the LastMileTracer from the Langchain and LlamaIndex instrumentors. This enables developers to use the tracer object to log extra events that aren't captured by auto-instrumentation.
