### PR TITLE
Make sure span_kind isn't overwritten in auto-instrumentors

### DIFF
--- a/src/tracing_auto_instrumentation/langchain/langchain_instrumentor.py
+++ b/src/tracing_auto_instrumentation/langchain/langchain_instrumentor.py
@@ -308,9 +308,8 @@ class _LastMileLangChainTracer(OpenInferenceTracer):
                     span=span,
                     event_data=serializable_payload,
                     should_also_save_in_span=True,
+                    span_kind=span_kind,
                 )
-
-            span.set_attribute(LASTMILE_SPAN_KIND_KEY_NAME, span_kind)
 
         # n.b. we can't use real time because the handler may be called in a background thread.
         end_time_utc_nano = (

--- a/src/tracing_auto_instrumentation/llama_index/llama_index_callback_handler.py
+++ b/src/tracing_auto_instrumentation/llama_index/llama_index_callback_handler.py
@@ -407,22 +407,19 @@ def _finish_tracing(
             # elif event_type == CBEventType.FUNCTION_CALL:
             #     tracer.add_tool_call_event(span_attributes[TOOL_NAME])
             else:
+                span_kind = str(event_data.event_type.value)
                 tracer.add_rag_event_for_span(
-                    event_name=str(event_data.event_type),
+                    event_name=span_kind,
                     span=span,
                     event_data=param_set_payload,
                     should_also_save_in_span=True,
+                    span_kind=span_kind,
                 )
             tracer.register_params(
                 params=param_set_payload,
                 should_also_save_in_span=True,
                 span=span,
             )
-
-        # Save span kind into span attribute, but don't add it to trace-level
-        # params (since that should be for trace-level data) or rag span event
-        # (since it's already used for the event name there)
-        span.set_attribute(LASTMILE_SPAN_KIND_KEY_NAME, event_data.event_type)
 
     except Exception:
         logger.exception(

--- a/src/tracing_auto_instrumentation/openai/openai_wrapper.py
+++ b/src/tracing_auto_instrumentation/openai/openai_wrapper.py
@@ -126,6 +126,9 @@ class ChatCompletionWrapper:
                         input=rag_event_input,
                         output=accumulated_text,
                         event_data=json.loads(rag_event_input),
+                        # TODO: Support tool calls
+                        # TODO: Use enum from lastmile-eval package
+                        span_kind="query",
                     )
 
                 yield from gen()
@@ -163,6 +166,9 @@ class ChatCompletionWrapper:
                         input=rag_event_input,
                         output=output,
                         event_data=json.loads(rag_event_input),
+                        # TODO: Support tool calls
+                        # TODO: Use enum from lastmile-eval package
+                        span_kind="query",
                     )
                 except Exception as e:
                     # TODO log this
@@ -241,6 +247,9 @@ class ChatCompletionWrapper:
                         input=rag_event_input,
                         output=accumulated_text,
                         event_data=json.loads(rag_event_input),
+                        # TODO: Support tool calls
+                        # TODO: Use enum from lastmile-eval package
+                        span_kind="query",
                     )
 
                 async for chunk in gen():
@@ -276,6 +285,9 @@ class ChatCompletionWrapper:
                         input=rag_event_input,
                         output=output,  # type: ignore
                         event_data=json.loads(rag_event_input),
+                        # TODO: Support tool calls
+                        # TODO: Use enum from lastmile-eval package
+                        span_kind="query",
                     )
                 except Exception as e:
                     # TODO log this
@@ -579,7 +591,9 @@ def _add_rag_event_with_output(
     input: Optional[Any] = None,
     output: Optional[Any] = None,
     event_data: dict[Any, Any] | None = None,
+    span_kind: Optional[str] = None,
 ) -> None:
+    # TODO: Replace with rag-specific API instead of add_rag_event_for_span
     if output is not None:
         tracer.add_rag_event_for_span(
             event_name,
@@ -587,6 +601,7 @@ def _add_rag_event_with_output(
             input=input,
             output=output,
             should_also_save_in_span=True,
+            span_kind=span_kind,
         )
     else:
         tracer.add_rag_event_for_span(
@@ -594,4 +609,5 @@ def _add_rag_event_with_output(
             span,  # type: ignore
             event_data=event_data,
             should_also_save_in_span=True,
+            span_kind=span_kind,
         )


### PR DESCRIPTION
Make sure span_kind isn't overwritten in auto-instrumentors

Now we support `span_kind` as an arg to our rag event APIs so we should just hook into that directly. Also left a few TODOs

## Test Plan
Run the ibm granite notebook and we now have the retrieval and query-specific spans properly rendered!
<img width="1624" alt="Screenshot 2024-06-19 at 13 40 39" src="https://github.com/lastmile-ai/tracing_auto_instrumentation/assets/151060367/d8617e8b-5e27-4e6c-9f30-5b1d1348083c">

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/lastmile-ai/tracing_auto_instrumentation/pull/69).
* #70
* __->__ #69