### PR TITLE
Break up openai_wrapper into separate files for async and sync wrappers

### DIFF
--- a/src/tracing_auto_instrumentation/openai/__init__.py
+++ b/src/tracing_auto_instrumentation/openai/__init__.py
@@ -1,4 +1,4 @@
-from .openai_wrapper import wrap_openai
+from .wrap_openai import wrap_openai
 
 __ALL__ = [
     wrap_openai.__name__,

--- a/src/tracing_auto_instrumentation/openai/shared.py
+++ b/src/tracing_auto_instrumentation/openai/shared.py
@@ -1,0 +1,63 @@
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+from typing import Any, Mapping, Optional, ParamSpecKwargs
+
+from lastmile_eval.rag.debugger.api import LastMileTracer
+from opentelemetry.trace import Span
+
+from ..utils import json_serialize_anything, T_co
+
+
+def parse_params(params: dict[str, ParamSpecKwargs]):
+    # First, destructively remove span_info
+    empty_dict: dict[str, Any] = {}
+    ret = params.pop("span_info", empty_dict)
+
+    # Then, copy the rest of the params
+    params = {**params}
+    messages = params.pop("messages", None)
+    return _merge_dicts(
+        ret,
+        {
+            "input": messages,
+            "metadata": params,
+        },
+    )
+
+
+def _merge_dicts(d1: dict[T_co, Any], d2: dict[T_co, Any]) -> dict[T_co, Any]:
+    return {**d1, **d2}
+
+
+def flatten_json(obj: Mapping[str, Any]):
+    return {k: json_serialize_anything(v) for k, v in obj.items()}
+
+
+def add_rag_event_with_output(
+    tracer: LastMileTracer,
+    event_name: str,
+    span: Optional[Span] = None,  # type: ignore
+    input: Optional[Any] = None,
+    output: Optional[Any] = None,
+    event_data: dict[Any, Any] | None = None,
+    span_kind: Optional[str] = None,
+) -> None:
+    # TODO: Replace with rag-specific API instead of add_rag_event_for_span
+    if output is not None:
+        tracer.add_rag_event_for_span(
+            event_name,
+            span,  # type: ignore
+            input=input,
+            output=output,
+            should_also_save_in_span=True,
+            span_kind=span_kind,
+        )
+    else:
+        tracer.add_rag_event_for_span(
+            event_name,
+            span,  # type: ignore
+            event_data=event_data,
+            should_also_save_in_span=True,
+            span_kind=span_kind,
+        )

--- a/src/tracing_auto_instrumentation/openai/wrap_openai.py
+++ b/src/tracing_auto_instrumentation/openai/wrap_openai.py
@@ -1,0 +1,38 @@
+from .openai_wrapper import OpenAIWrapper
+from .async_openai_wrapper import AsyncOpenAIWrapper
+from lastmile_eval.rag.debugger.api import LastMileTracer
+
+import openai
+
+
+def wrap_openai(
+    client: openai.OpenAI | openai.AsyncOpenAI,
+    tracer: LastMileTracer,
+) -> OpenAIWrapper | AsyncOpenAIWrapper:
+    """
+    Wrap an OpenAI Client to add LastMileTracer so that
+    any calls to it will contain tracing data.
+
+    Currently only v1 API is supported, which was released November 6, 2023:
+        https://stackoverflow.com/questions/77435356/openai-api-new-version-v1-of-the-openai-python-package-appears-to-contain-bre
+    We also only support `/v1/chat/completions` api and not `/v1/completions`
+
+    :param client: OpenAI client created using openai.OpenAI()
+
+    Example usage:
+    ```python
+    import openai
+    from tracing_auto_instrumentation.openai import wrap_openai
+    from lastmile_eval.rag.debugger.tracing.sdk import get_lastmile_tracer
+
+    tracer = get_lastmile_tracer(
+        tracer_name="my-tracer-name",
+        lastmile_api_token="my-lastmile-api-token",
+    )
+    client = wrap_openai(openai.OpenAI(), tracer)
+    # Use client as you would normally use the OpenAI client
+    ```
+    """
+    if isinstance(client, openai.OpenAI):
+        return OpenAIWrapper(client, tracer)
+    return AsyncOpenAIWrapper(client, tracer)

--- a/src/tracing_auto_instrumentation/utils.py
+++ b/src/tracing_auto_instrumentation/utils.py
@@ -1,13 +1,16 @@
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
 import json
 from typing import Any, Generic, TypeVar
 
 
-T_INV = TypeVar("T_INV")
+T_co = TypeVar("T_co", covariant=True)
 DEFAULT_TRACER_NAME_PREFIX = "LastMileTracer"
 
 
-class NamedWrapper(Generic[T_INV]):
-    def __init__(self, wrapped: T_INV):
+class NamedWrapper(Generic[T_co]):
+    def __init__(self, wrapped: T_co):
         self.__wrapped = wrapped
 
     def __getattr__(self, name: str):


### PR DESCRIPTION
Break up openai_wrapper into separate files for async and sync wrappers

Also created a shared file and the exposed `wrap_openai.py` file that is the true wrapper around both of them

I think this is much cleaner and easier to read through. Keeps everything more streamlined and strictly typed

There are no functional changes in this PR

## Test Plan
Run the openai notebooks
